### PR TITLE
Declare attributes inside constructor [bug]

### DIFF
--- a/Simulation.py
+++ b/Simulation.py
@@ -3,14 +3,11 @@ import logging
 
 
 class Simulation:
-    question_processing_daemon = None
-    simulation_settings = None
-
-    should_execute_question_processing = False
-    should_execute_information_retrieval = False
-
     def __init__(self, simulation_settings):
         self.simulation_settings = simulation_settings
+        self.question_processing_daemon = None
+        self.should_execute_question_processing = False
+        self.should_execute_information_retrieval = False
 
         # check in the configuration file which steps should be executed
         if ("questionProcessing" in self.simulation_settings) and (self.simulation_settings["questionProcessing"]["should_execute"]):

--- a/questionprocessing/DatasetController.py
+++ b/questionprocessing/DatasetController.py
@@ -3,15 +3,11 @@ from collections import deque
 
 
 class DatasetController(metaclass=abc.ABCMeta):
-    question_processing_settings = None
-    question_metadata_parameters = []
-    question_text_parameter = ''
-    questions = None  # double-ended queue - deque()
-
     def __init__(self, settings):
         self.question_processing_settings = settings
         self.question_metadata_parameters = self.get_question_metadata_parameters()
         self.question_text_parameter = self.get_question_text_parameter()
+        self.questions = None  # double-ended queue - deque()
 
     def set_questions(self, questions):
         self.questions = questions

--- a/questionprocessing/QuestionProcessingDaemon.py
+++ b/questionprocessing/QuestionProcessingDaemon.py
@@ -4,12 +4,10 @@ import logging
 
 
 class QuestionProcessingDaemon:
-    settings = {}
-    dataset_controller = None
-    question_parser = None
-
     def __init__(self, question_processing_settings):
         self.settings = question_processing_settings
+        self.dataset_controller = None
+        self.question_parser = None
 
     def __build_dataset_controller(self):
         try:

--- a/questionprocessing/QuestionProcessingParser.py
+++ b/questionprocessing/QuestionProcessingParser.py
@@ -4,8 +4,6 @@ import nltk
 
 
 class QuestionProcessingParser:
-    question_processing_settings = None
-
     def __init__(self, settings):
         self.question_processing_settings = settings
 

--- a/questionprocessing/WikiPassageQADatasetController.py
+++ b/questionprocessing/WikiPassageQADatasetController.py
@@ -6,8 +6,6 @@ from questionprocessing.Question import Question
 
 
 class WikiPassageQADatasetController(DatasetController):
-    # questions objects are indexed in the dictionary by the identification parameter
-    questions = deque()
 
     def get_question_metadata_parameters(self):
         return ['QID', 'Question', 'DocumentID', 'DocumentName', 'RelevantPassages']
@@ -19,6 +17,10 @@ class WikiPassageQADatasetController(DatasetController):
         return 'QID'
 
     def load_all_questions(self, questions=deque()):
+        if self.questions is None:
+            # questions objects are indexed in the dictionary by the identification parameter
+            questions = deque()
+
         try:
             path = self.question_processing_settings['dataset']['path']
             data = pd.read_csv(path + 'dev.tsv', sep='\t')
@@ -35,7 +37,6 @@ class WikiPassageQADatasetController(DatasetController):
                 for parameter in self.question_metadata_parameters:
                     value = row[parameter]
                     question.insert_metadata_value(parameter, value)
-
                 questions.append(question)
 
             return questions


### PR DESCRIPTION
Nesse issue os atributos foram definidos dentro dos construtores das classes. Isso evita que o atributo seja vinculado ao mesmo valor para todos os objetos da classe que são instanciados durante a execução do programa.