### PR TITLE
Adjusting load_entries output format [enhancement]

### DIFF
--- a/config/step2_pipeline.json
+++ b/config/step2_pipeline.json
@@ -2,13 +2,13 @@
   "datasets": [
     {
       "reader_type": "WikiPassageQA",
-      "name": "WikiPassageQADev",
+      "name": "WikiPassageQA",
       "path": "datasets/WikiPassageQA/dev.tsv"
     },
     {
-      "reader_type": "WikiPassageQA",
-      "name": "WikiPassageQATest",
-      "path": "datasets/WikiPassageQA/test.tsv"
+      "reader_type": "QAChave",
+      "name": "QAChave",
+      "path": "datasets/qa-chave/"
     }
   ],
   "pipeline":
@@ -19,18 +19,8 @@
           "task": "SimpleSplit",
           "datasets": [
             {
-              "name": "WikiPassageQADev",
+              "name": "WikiPassageQA",
               "input_fields": {
-                "dataset_question_text": "Question",
-                "dataset_question_id": "QID"
-              },
-              "evaluation_fields": {}
-            },
-            {
-              "name": "WikiPassageQATest",
-              "input_fields": {
-                "dataset_question_text": "",
-                "dataset_question_id": ""
               },
               "evaluation_fields": {}
             }
@@ -42,18 +32,9 @@
           "task": "DeepSearch",
           "datasets": [
             {
-              "name": "WikiPassageQADev",
+              "name": "WikiPassageQA",
               "input_fields": {
-                "dataset_question_id": "QID",
                 "query": "result_task0"
-              },
-              "evaluation_fields": {}
-            },
-            {
-              "name": "WikiPassageQATest",
-              "input_fields": {
-                "dataset_question_id": "",
-                "query": ""
               },
               "evaluation_fields": {}
             }

--- a/src/Pipeline.py
+++ b/src/Pipeline.py
@@ -17,9 +17,9 @@ class Pipeline:
     def run_tasks(self):
         try:
             for task in self.tasks:
-                fields_to_map = Settings.get_instance().get_mapped_fields(task.get_id())
+                fields_to_map_task_result = Settings.get_instance().get_mapped_fields(task.get_id())
 
-                # Get the datasets that are configured for the task
+                # Get the dataset reader types that are configured for the task
                 expected_datasets = set()
                 for expected_dataset_name in Settings.get_instance().get_expected_datasets(task.get_id()):
                     expected_datasets.add(Settings.get_instance().get_dataset_reader_type(expected_dataset_name))
@@ -33,7 +33,7 @@ class Pipeline:
                             task.validate_resource_entry(resource_entry)
                             task_result = task.run_technique(resource_entry)
                             # Insert the generated result in all fields of the resource entry that expect the value.
-                            for field in fields_to_map:
+                            for field in fields_to_map_task_result:
                                 resource_entry.add_mapped_value(field, task_result)
         except Exception as e:
             logging.error(str(e))

--- a/src/Resource.py
+++ b/src/Resource.py
@@ -42,13 +42,12 @@ class Resource:
         :return: dataset_reader (DatasetReader).
         """
         dataset_path = Settings.get_instance().get_dataset_path(self.dataset_name)
-        dataset_fields_to_read = self.__get_dataset_fields()
 
         # Create dataset reader object.
         if self.dataset_reader_type == ImplementedDatasetReaders.DatasetWikiPassageQA:
-            dataset_reader = DatasetReaderWikiPassageQA(self.dataset_name, dataset_path, dataset_fields_to_read)
+            dataset_reader = DatasetReaderWikiPassageQA(self.dataset_name, dataset_path)
         elif self.dataset_reader_type == ImplementedDatasetReaders.DatasetQAChave:
-            dataset_reader = DatasetReaderQAChave(self.dataset_name, dataset_path, dataset_fields_to_read)
+            dataset_reader = DatasetReaderQAChave(self.dataset_name, dataset_path)
         else:
             logging.error("Dataset type " + self.dataset_reader_type + " not implemented")
             dataset_reader = None
@@ -64,14 +63,11 @@ class Resource:
             entries_from_dataset = dataset_reader.load_entries()
 
             if entries_from_dataset is not None:
-                # For each entry that was read from the dataset.
-                for index, row in entries_from_dataset.iterrows():
+                # For each entry that was read from the dataset
+                for entry in entries_from_dataset:
                     # Creates a resource entry.
                     resource_entry = ResourceEntry(self.field_mapping.keys())
-
-                    for field in entries_from_dataset.columns.values:
-                        # Add the value of the field in the newly created object.
-                        resource_entry.add_mapped_value(self.__field_key_from_value(field), row[field])
+                    resource_entry.append_dictionary_values(entry)
 
                     self.resource_entries.append(resource_entry)
             else:

--- a/src/ResourceEntry.py
+++ b/src/ResourceEntry.py
@@ -16,3 +16,7 @@ class ResourceEntry:
 
     def add_mapped_value(self, field, value):
         self.field_value_mapping[field] = value
+
+    def append_dictionary_values(self, d):
+        for key, value in d.items():
+            self.add_mapped_value(key, value)

--- a/src/Settings.py
+++ b/src/Settings.py
@@ -23,14 +23,16 @@ class Settings:
 
     @staticmethod
     def get_dataset_path(dataset_name):
-        return './datasets/WikiPassageQA/dev.tsv'
-        #return ''
+        if dataset_name == 'WikiPassageQA':
+            return './datasets/WikiPassageQA/'
+        elif dataset_name == 'QAChave':
+            return './datasets/qa-chave'
+        else:
+            return ''
 
     @staticmethod
     def get_field_mapping(dataset_name):
-        return {"dataset_question_text": "Question",
-                "dataset_question_id": "QID",
-                "query": None}
+        return {'query': 'result_task0'}
 
     @staticmethod
     def get_dataset_input_fields(dataset_name):
@@ -43,16 +45,14 @@ class Settings:
         :return: List with all dataset names.
         """
         if task_id == 0:
-            return ['WikiPassageQADev', 'WikiPassageQATest']
+            return ['WikiPassageQA', 'QAChave']
         return None
 
     @staticmethod
     def get_dataset_reader_type(dataset_name):
-        reader_name = 'WikiPassageQA' # search this information in the config file
-
-        if reader_name == 'WikiPassageQA':
+        if dataset_name == 'WikiPassageQA':
             return ImplementedDatasetReaders.DatasetWikiPassageQA
-        elif reader_name == 'QAChave':
+        elif dataset_name == 'QAChave':
             return ImplementedDatasetReaders.DatasetQAChave
         return None
 

--- a/src/datasetreader/DatasetReader.py
+++ b/src/datasetreader/DatasetReader.py
@@ -2,15 +2,14 @@ import abc
 
 
 class DatasetReader:
-    def __init__(self, name, path, fields_to_read):
+    def __init__(self, name, path):
         self.name = name
         self.path = path
-        self.fields_to_read = fields_to_read
 
     @abc.abstractmethod
     def load_entries(self):
         """
-        Loads, from the dataset, all the values of the fields maintained in attribute fields_to_read.
-        :return: dataframe with the values of the fields maintained in attribute fields_to_read.
+        Load the information from the dataset.
+        :return: dictionary with the values that were read from the dataset.
         """
         pass

--- a/src/datasetreader/DatasetReaderWikiPassageQA.py
+++ b/src/datasetreader/DatasetReaderWikiPassageQA.py
@@ -5,10 +5,85 @@ import pandas as pd
 
 class DatasetReaderWikiPassageQA(DatasetReader):
     def load_entries(self):
-        fields = [x for x in self.fields_to_read]
         try:
-            data = pd.read_csv(self.path, sep='\t', usecols=fields)
-            return data
+            read_entries = []
+
+            # Load train file
+            raw_dataframe = pd.read_csv(self.path + '/train.tsv', sep='\t')
+            for index, row in raw_dataframe.iterrows():
+                row = {
+                    "id": row["QID"],
+                    "question": row["Question"],
+                    "answers": [
+                        {
+                            "documents": [
+                                {
+                                    "id": row["DocumentID"],
+                                    "name": row["DocumentName"],
+                                }
+                            ],
+                            "passages": [
+                                {
+                                    "passage": row["RelevantPassages"]
+                                }
+                            ],
+                        }
+                    ],
+                    "pre_evaluation_group": "train",
+                }
+                read_entries.append(row)
+
+            # Load dev file
+            raw_dataframe = pd.read_csv(self.path + '/dev.tsv', sep='\t')
+            for index, row in raw_dataframe.iterrows():
+                row = {
+                    "id": row["QID"],
+                    "question": row["Question"],
+                    "answers": [
+                        {
+                            "documents": [
+                                {
+                                    "id": row["DocumentID"],
+                                    "name": row["DocumentName"],
+                                }
+                            ],
+                            "passages": [
+                                {
+                                    "passage": row["RelevantPassages"]
+                                }
+                            ],
+                        }
+                    ],
+                    "pre_evaluation_group": "dev",
+                }
+                read_entries.append(row)
+
+            # Load test file
+            raw_dataframe = pd.read_csv(self.path + '/test.tsv', sep='\t')
+            for index, row in raw_dataframe.iterrows():
+                row = {
+                    "id": row["QID"],
+                    "question": row["Question"],
+                    "answers": [
+                        {
+                            "documents": [
+                                {
+                                    "id": row["DocumentID"],
+                                    "name": row["DocumentName"],
+                                }
+                            ],
+                            "passages": [
+                                {
+                                    "passage": row["RelevantPassages"]
+                                }
+                            ],
+                        }
+                    ],
+                    "pre_evaluation_group": "test",
+                }
+                read_entries.append(row)
+
+            return read_entries
 
         except Exception as e:
             logging.error(str(e))

--- a/src/main.py
+++ b/src/main.py
@@ -16,13 +16,19 @@ if __name__ == '__main__':
     # simulation.run()
 
     # Tests and debug
-    resource0 = Resource('WikiPassageQADev', ImplementedDatasetReaders.DatasetWikiPassageQA)
+    resource0 = Resource('WikiPassageQA', ImplementedDatasetReaders.DatasetWikiPassageQA)
     resource0.build_resource_entries()
+
+    resource1 = Resource('QAChave', ImplementedDatasetReaders.DatasetQAChave)
+    resource1.build_resource_entries()
 
     task0 = TaskSimpleSplit(0)
 
     pipeline = Pipeline()
     pipeline.add_resource(resource0)
+    pipeline.add_resource(resource1)
     pipeline.add_task(task0)
 
     pipeline.run_tasks()
+
+    pass

--- a/src/tasks/TaskSimpleSplit.py
+++ b/src/tasks/TaskSimpleSplit.py
@@ -7,8 +7,7 @@ from nltk.corpus import stopwords
 class TaskSimpleSplit(Task):
     @staticmethod
     def get_fields_for_technique():
-        return ['dataset_question_text',
-                'dataset_question_id']
+        return []
 
     def run_technique(self, resource_entry):
         try:
@@ -22,7 +21,7 @@ class TaskSimpleSplit(Task):
             nltk.download('stopwords')  # downloads only once
 
         stop_words = set(stopwords.words('english'))
-        question_text = resource_entry.get_value('dataset_question_text')
+        question_text = resource_entry.get_value('question')
 
         try:
             tokens = nltk.word_tokenize(question_text)  # generate tokens


### PR DESCRIPTION
Now, both datasets "WikiPassegeQA' and "QAChave" have its entries standardized in the following structure:

```python
resource_entry = {
    "id": None,
    "question": None,
    "question_domain": None,
    "answer_type": None,
    "answers": [{"id": None, "answer": None,
                 "documents": [{"id": None, "name": None, "document": None}],
                 "passages": [{"id": None, "name": None, "passage": None}],
                 "sentences": [{"id": None, "name": None, "sentence": None}]}
                ],
    "entities": [{"entity": None, "start": None, "end": None, "type": None, "subtype": None}],
    "tokens": [],

    # When the collection contains a predefined division of training, dev, and test data,
    # this column determines which group this question belongs to. Possible values: NaN, train, dev, test.
    "pre_evaluation_group": None,

    "evaluation_group": None,
}
```